### PR TITLE
Enable to set custom GitHub url

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,13 @@ Required String (only if `pullRequestEnabled` is `true`).
 
     gitHubWriteToken = "123"
 
+
+###### GitHub Api Host Name
+
+The GitHub api host name needed to access the GitHub Enterprise. Optional String.
+
+    gitHubApiHostName = "your.githubenterprise.com"
+
 ### Privacy Policy
 
 The `listDependenciesToUpgrade` & `upgradeDependencies` tasks send to **Releases Hub** servers the **groupId**, **artifactId** and **version** of the project dependencies, in order to process and fetch the artifacts updates. 

--- a/releases-hub-gradle-plugin/src/main/java/com/releaseshub/gradle/plugin/ReleasesHubGradlePlugin.kt
+++ b/releases-hub-gradle-plugin/src/main/java/com/releaseshub/gradle/plugin/ReleasesHubGradlePlugin.kt
@@ -52,6 +52,7 @@ class ReleasesHubGradlePlugin : Plugin<Project> {
             upgradeDependenciesTask.gitHubRepositoryOwner = extension.gitHubRepositoryOwner
             upgradeDependenciesTask.gitHubRepositoryName = extension.gitHubRepositoryName
             upgradeDependenciesTask.gitHubWriteToken = extension.gitHubWriteToken
+            upgradeDependenciesTask.gitHubApiUrl = extension.gitHubApiHostName
         }
     }
 

--- a/releases-hub-gradle-plugin/src/main/java/com/releaseshub/gradle/plugin/ReleasesHubGradlePlugin.kt
+++ b/releases-hub-gradle-plugin/src/main/java/com/releaseshub/gradle/plugin/ReleasesHubGradlePlugin.kt
@@ -52,7 +52,7 @@ class ReleasesHubGradlePlugin : Plugin<Project> {
             upgradeDependenciesTask.gitHubRepositoryOwner = extension.gitHubRepositoryOwner
             upgradeDependenciesTask.gitHubRepositoryName = extension.gitHubRepositoryName
             upgradeDependenciesTask.gitHubWriteToken = extension.gitHubWriteToken
-            upgradeDependenciesTask.gitHubApiUrl = extension.gitHubApiHostName
+            upgradeDependenciesTask.gitHubApiHostName = extension.gitHubApiHostName
         }
     }
 

--- a/releases-hub-gradle-plugin/src/main/java/com/releaseshub/gradle/plugin/ReleasesHubGradlePluginExtension.kt
+++ b/releases-hub-gradle-plugin/src/main/java/com/releaseshub/gradle/plugin/ReleasesHubGradlePluginExtension.kt
@@ -50,6 +50,7 @@ open class ReleasesHubGradlePluginExtension(project: Project) {
     var gitHubRepositoryOwner: String? = propertyResolver.getStringProp(::gitHubRepositoryOwner.name)
     var gitHubRepositoryName: String? = propertyResolver.getStringProp(::gitHubRepositoryName.name)
     var gitHubWriteToken: String? = propertyResolver.getStringProp(::gitHubWriteToken.name)
+    var gitHubApiHostName: String? = propertyResolver.getStringProp(::gitHubApiHostName.name)
 
     var logLevel = LogLevel.LIFECYCLE
 

--- a/releases-hub-gradle-plugin/src/main/java/com/releaseshub/gradle/plugin/task/UpgradeDependenciesTask.kt
+++ b/releases-hub-gradle-plugin/src/main/java/com/releaseshub/gradle/plugin/task/UpgradeDependenciesTask.kt
@@ -32,7 +32,7 @@ open class UpgradeDependenciesTask : AbstractTask() {
     var gitHubRepositoryOwner: String? = null
     var gitHubRepositoryName: String? = null
     var gitHubWriteToken: String? = null
-    var gitHubApiUrl: String? = null
+    var gitHubApiHostName: String? = null
 
     init {
         description = "Upgrade dependencies"
@@ -195,7 +195,12 @@ open class UpgradeDependenciesTask : AbstractTask() {
         // We add this delay to automatically fix this: https://support.circleci.com/hc/en-us/articles/360034536433-Pull-requests-not-building-due-to-Only-build-pull-requests-settings
         ExecutorUtils.sleep(10, TimeUnit.SECONDS)
 
-        val client = GitHubClient()
+        val client = if (gitHubApiHostName.isNullOrEmpty()) {
+            GitHubClient()
+        } else {
+            GitHubClient(gitHubApiHostName)
+        }
+
         client.setSerializeNulls(false)
         client.setOAuth2Token(gitHubWriteToken)
 

--- a/releases-hub-gradle-plugin/src/main/java/com/releaseshub/gradle/plugin/task/UpgradeDependenciesTask.kt
+++ b/releases-hub-gradle-plugin/src/main/java/com/releaseshub/gradle/plugin/task/UpgradeDependenciesTask.kt
@@ -32,6 +32,7 @@ open class UpgradeDependenciesTask : AbstractTask() {
     var gitHubRepositoryOwner: String? = null
     var gitHubRepositoryName: String? = null
     var gitHubWriteToken: String? = null
+    var gitHubApiUrl: String? = null
 
     init {
         description = "Upgrade dependencies"


### PR DESCRIPTION
Hi, thanks for your amazing library.

I want to use this library in the project managed at GitHub Enterprise. So, enabled to set custom GitHub URL via property.

To connect to GitHub, this library uses https://github.com/maxirosson/jdroid-java-github which I thought it could use custom GitHub URL. So, changed only in this library.

If not, I will send pull-request to [https://github.com/maxirosson/jdroid-java-github](https://github.com/maxirosson/jdroid-java-github)!