### PR TITLE
Add gradle distribution type configuration option

### DIFF
--- a/releases-hub-gradle-plugin/src/main/java/com/releaseshub/gradle/plugin/ReleasesHubGradlePlugin.kt
+++ b/releases-hub-gradle-plugin/src/main/java/com/releaseshub/gradle/plugin/ReleasesHubGradlePlugin.kt
@@ -59,6 +59,7 @@ class ReleasesHubGradlePlugin : Plugin<Project> {
             upgradeDependenciesTask.gitHubRepositoryName = extension.gitHubRepositoryName
             upgradeDependenciesTask.gitHubWriteToken = extension.gitHubWriteToken
             upgradeDependenciesTask.gitHubApiHostName = extension.gitHubApiHostName
+            upgradeDependenciesTask.gradleDistributionType = extension.gradleDistributionType
         }
     }
 

--- a/releases-hub-gradle-plugin/src/main/java/com/releaseshub/gradle/plugin/ReleasesHubGradlePluginExtension.kt
+++ b/releases-hub-gradle-plugin/src/main/java/com/releaseshub/gradle/plugin/ReleasesHubGradlePluginExtension.kt
@@ -49,6 +49,8 @@ open class ReleasesHubGradlePluginExtension(project: Project) {
     var gitHubWriteToken: String? = project.propertyResolver.getStringProp(::gitHubWriteToken.name)
     var gitHubApiHostName: String? = project.propertyResolver.getStringProp(::gitHubApiHostName.name)
 
+    var gradleDistributionType: String? = project.propertyResolver.getStringProp(::gradleDistributionType.name) ?: "bin"
+
     var logLevel = LogLevel.LIFECYCLE
 
     fun validateServerName() {

--- a/releases-hub-gradle-plugin/src/main/java/com/releaseshub/gradle/plugin/task/DependenciesUpgrader.kt
+++ b/releases-hub-gradle-plugin/src/main/java/com/releaseshub/gradle/plugin/task/DependenciesUpgrader.kt
@@ -22,13 +22,13 @@ object DependenciesUpgrader {
         return UpgradeResult(false, null, line)
     }
 
-    fun upgradeGradle(commandExecutor: CommandExecutor, rootDir: File, artifactToUpgrade: ArtifactUpgrade): UpgradeResult {
+    fun upgradeGradle(commandExecutor: CommandExecutor, rootDir: File, artifactToUpgrade: ArtifactUpgrade, distributionType: String): UpgradeResult {
         val gradleWrapperPropertiesContent = GradleHelper.getGradleWrapperPropertiesFile(rootDir).readText()
         val gradlewBatFile = GradleHelper.getGradleBatWrapperFile(rootDir)
         val keepGradleBatFile = gradlewBatFile.exists()
 
         // We execute this twice because I had cases in the past where I had to do that to upgrade all files
-        val upgradeCommand = "./gradlew wrapper --gradle-version=${artifactToUpgrade.toVersion!!} --stacktrace"
+        val upgradeCommand = "./gradlew wrapper --gradle-version=${artifactToUpgrade.toVersion!!} --distribution-type=$distributionType --stacktrace"
         try {
             commandExecutor.execute(upgradeCommand)
             commandExecutor.execute(upgradeCommand)

--- a/releases-hub-gradle-plugin/src/main/java/com/releaseshub/gradle/plugin/task/UpgradeDependenciesTask.kt
+++ b/releases-hub-gradle-plugin/src/main/java/com/releaseshub/gradle/plugin/task/UpgradeDependenciesTask.kt
@@ -70,6 +70,9 @@ open class UpgradeDependenciesTask : AbstractTask() {
     @get:Optional
     var gitHubApiHostName: String? = null
 
+    @get:Input
+    var gradleDistributionType: String? = null
+
     init {
         description = "Upgrade dependencies"
     }
@@ -179,7 +182,7 @@ open class UpgradeDependenciesTask : AbstractTask() {
             var upgradedUpgradeResult: UpgradeResult? = null
 
             if (artifactToUpgrade.id == ArtifactUpgrade.GRADLE_ID) {
-                val upgradeResult = DependenciesUpgrader.upgradeGradle(commandExecutor, project.rootProject.projectDir, artifactToUpgrade)
+                val upgradeResult = DependenciesUpgrader.upgradeGradle(commandExecutor, project.rootProject.projectDir, artifactToUpgrade, gradleDistributionType!!)
                 if (upgradeResult.upgraded) {
                     upgradeResults.add(upgradeResult)
                     log(" - ${upgradeResult.artifactUpgrade} ${upgradeResult.artifactUpgrade?.fromVersion} -> ${upgradeResult.artifactUpgrade?.toVersion}")


### PR DESCRIPTION
Thank you for the very useful plugin.

Default gradle distribution type is `bin` but type `all` is used in some projects.
So, I added the option to control gradle distribution type when upgrading using `--distribution-type` command option.

https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:adding_wrapper
