### PR TITLE
Use WeakHashMap for propertyResolverCache

### DIFF
--- a/releases-hub-gradle-plugin/src/main/java/com/releaseshub/gradle/plugin/common/ProjectExtensions.kt
+++ b/releases-hub-gradle-plugin/src/main/java/com/releaseshub/gradle/plugin/common/ProjectExtensions.kt
@@ -1,8 +1,9 @@
 package com.releaseshub.gradle.plugin.common
 
 import org.gradle.api.Project
+import java.util.WeakHashMap
 
-private val propertyResolverCache = mutableMapOf<Project, PropertyResolver>()
+private val propertyResolverCache = WeakHashMap<Project, PropertyResolver>()
 
 val Project.propertyResolver: PropertyResolver
     get() = propertyResolverCache.getOrPut(this) { PropertyResolver(this) }


### PR DESCRIPTION
First thanks for creating this useful plugin.😃

Our project periodically went OOM.
After dumping the heap it seems like the global `propertyResolverCache` caused the leak.
I'm not very familiar with the Gradle plugin, maybe change the cache to WeachHashMap can fix this problem.
Thanks! 

<img width="905" alt="Screen Shot 2020-10-20 at 16 37 58" src="https://user-images.githubusercontent.com/13031690/96557547-5eb2dd80-12f5-11eb-8a29-1bd6c060ae5e.png">
